### PR TITLE
Update keripy.dockerfile

### DIFF
--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=python:3.12.3-alpine3.20
+ARG BASE=python:3.13.2-alpine3.20
 
 FROM ${BASE} AS builder
 


### PR DESCRIPTION
* Correct the default value of `BASE` in `images/keripy.dockerfile`, the minimum version of Python per `setup.py` is 3.13.2, without this change the `keripy` container cannot be built without overriding the `BASE` value